### PR TITLE
Remove "#nullable enable" directives as NRT is now enabled in the project file.

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.PBST.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.PBST.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 internal static partial class Interop
 {
     internal static partial class ComCtl32

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.PFTASKDIALOGCALLBACK.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.PFTASKDIALOGCALLBACK.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TASKDIALOGCONFIG.IconUnion.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TASKDIALOGCONFIG.IconUnion.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TASKDIALOGCONFIG.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TASKDIALOGCONFIG.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TASKDIALOG_BUTTON.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TASKDIALOG_BUTTON.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TDCBF.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TDCBF.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 internal static partial class Interop

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TDE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TDE.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 internal static partial class Interop
 {
     internal static partial class ComCtl32

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TDF.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TDF.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 internal static partial class Interop

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TDIE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TDIE.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 internal static partial class Interop
 {
     internal static partial class ComCtl32

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TDM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TDM.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 internal static partial class Interop
 {
     internal static partial class ComCtl32

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TDN.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TDN.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 internal static partial class Interop
 {
     internal static partial class ComCtl32

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TaskDialogIndirect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TaskDialogIndirect.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Runtime.InteropServices;
 


### PR DESCRIPTION
Remove `#nullable enable` directives from code files in `System.Windows.Forms.Primitives` added by dotnet#1133, as NRT is now enabled in the project file.